### PR TITLE
Add ability to obtain database separately.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Changelog for timezone-detect
 
+## v0.3.0.0 (2020-09-02)
+
+* Introduce `openTimeZoneDatabase` and `closeTimeZoneDatabase` to hew closer to
+  the underlying library's intended usage.
+* Changes the signature of `lookupTimeZoneName` to take a timezone database, not
+  a file.
+* Introduces the `FromFile` variant that _does_ look up the timezone in a file.
+
 ## v0.2.2.0 (2020-08-30)
 
 * Explicitly import `MonadFail` and `fail`; hide the `fail` from `Prelude`.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,11 +2,15 @@
 
 ## v0.3.0.0 (2020-09-02)
 
+**Breaking Changes!**
+
 * Introduce `openTimeZoneDatabase` and `closeTimeZoneDatabase` to hew closer to
-  the underlying library's intended usage.
+  the underlying library's intended usage. And `withTimeZoneDatabase` manage the
+  opening and closing of the TZ file around an IO computation with it.
 * Changes the signature of `lookupTimeZoneName` to take a timezone database, not
-  a file.
-* Introduces the `FromFile` variant that _does_ look up the timezone in a file.
+  a file, same with `timeAtPointToUTC`. Introduces `*FromFile` variants that
+  work with the path to the DB file and manage the opening/closing.
+
 
 ## v0.2.2.0 (2020-08-30)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,7 @@
 **Breaking Changes!**
 
 * Introduce `openTimeZoneDatabase` and `closeTimeZoneDatabase` to hew closer to
-  the underlying library's intended usage. And `withTimeZoneDatabase` manage the
+  the underlying library's intended usage. And `withTimeZoneDatabase` to manage the
   opening and closing of the TZ file around an IO computation with it.
 * Changes the signature of `lookupTimeZoneName` to take a timezone database, not
   a file, same with `timeAtPointToUTC`. Introduces `*FromFile` variants that

--- a/README.md
+++ b/README.md
@@ -9,24 +9,33 @@ UNIX-aware facilities to determine the UTC time of a given local time in a latit
 ## Usage
 
 You'll need timezone database files to work with this library, see instructions [in the original repository](https://github.com/BertoldVdb/ZoneDetect/tree/master/database).
+A copy is provided in the `test` directory of this repository, but it's intentionally not bundled in the package. We make no guarantees of its correctness,
+we recommend you use the original authors' files!
+
+
+### Timezone Name Lookup
 
 Once you have those files in hand, you'll be able to get a timezone from a given latitude and longitude:
 
 ```haskell
 >>> db <- openTimeZoneDatabase "./test/tz_db/timezone21.bin" 
->>> tz <- lookupTimeZoneName db 40.7831 (-73.9712) :: Maybe TimeZoneName
+>>> let tz = lookupTimeZoneName db 40.7831 (-73.9712) :: Maybe TimeZoneName
 Just "America/New_York"
 >>> closeTimeZoneDatabase db
 ```
 
-A convenience function that opens and closes the file when done is also provided, specialized to `IO`:
+You can use `withTimeZoneDatabase` to "bracket" access to the file (take care of opening and closing,)
+but if all you want to do is do a one-off lookup, a convenience function that opens and closes the file when done
+is also provided, specialized to `IO`:
 
 ```haskell
-tz <- lookupTimeZoneNameFromFile "./test/tz_db/timezone21.bin" 40.7831 (-73.9712)
+>>> tz <- lookupTimeZoneNameFromFile "./test/tz_db/timezone21.bin" 40.7831 (-73.9712)
 "America/New_York"
 ```
 
-Additionally, we now depend on the [timezone-series](https://hackage.haskell.org/package/timezone-series) and [timezone-olson](https://hackage.haskell.org/package/timezone-olson) packages to add awareness of `tz database` information.
+### LocalTime to UTCTime conversion
+
+Additionally, we depend on the [timezone-series](https://hackage.haskell.org/package/timezone-series) and [timezone-olson](https://hackage.haskell.org/package/timezone-olson) packages to add awareness of `tz database` information.
 
 With that, you can look up the UTC time at a point in time and space:
 
@@ -40,6 +49,7 @@ With that, you can look up the UTC time at a point in time and space:
 >>> localSummer <- parseTimeM True defaultTimeLocale "%Y-%-m-%-d %T" "2019-07-25 00:30:00"
 >>> utcTime <- timeAtPointToUTC db 40.7831 (-73.9712) localWinter
 2019-07-25 04:30:00 UTC
+>>> closeTimeZoneDatabase db
 ```
 
 You can also opt to obtain the timezone name separately (if you wanted to isolate that as a failure scenario,)
@@ -50,3 +60,31 @@ and, once in possession of it, use `timeInTimeZoneToUTC`:
 >>> utcTime <- timeInTimeZoneToUTC "America/New_York" localSummer
 2019-07-25 04:30:00 UTC
 ```
+
+## Copyright
+
+This library is released under the GPL v2; but the license for the underlying C library bears the following copyright:
+
+> Copyright (c) 2018, Bertold Van den Bergh (vandenbergh@bertold.org) 
+> All rights reserved.
+> Redistribution and use in source and binary forms, with or without
+> modification, are permitted provided that the following conditions are met:
+>    * Redistributions of source code must retain the above copyright
+>       notice, this list of conditions and the following disclaimer.
+>    * Redistributions in binary form must reproduce the above copyright
+>       notice, this list of conditions and the following disclaimer in the
+>       documentation and/or other materials provided with the distribution.
+>    * Neither the name of the author nor the
+>       names of its contributors may be used to endorse or promote products
+>       derived from this software without specific prior written permission.
+>
+> THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+> ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+> WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+> DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR DISTRIBUTOR BE LIABLE FOR ANY
+> DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+> (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+> LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+> ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+> (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+> SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,17 @@ You'll need timezone database files to work with this library, see instructions 
 Once you have those files in hand, you'll be able to get a timezone from a given latitude and longitude:
 
 ```haskell
->>> lookupTimeZoneName "./test/tz_db/timezone21.bin" 40.7831 (-73.9712) :: Maybe TimeZoneName
+>>> db <- openTimeZoneDatabase "./test/tz_db/timezone21.bin" 
+>>> tz <- lookupTimeZoneName db 40.7831 (-73.9712) :: Maybe TimeZoneName
 Just "America/New_York"
+>>> closeTimeZoneDatabase db
+```
+
+A convenience function that opens and closes the file when done is also provided, specialized to `IO`:
+
+```haskell
+tz <- lookupTimeZoneNameFromFile "./test/tz_db/timezone21.bin" 40.7831 (-73.9712)
+"America/New_York"
 ```
 
 Additionally, we now depend on the [timezone-series](https://hackage.haskell.org/package/timezone-series) and [timezone-olson](https://hackage.haskell.org/package/timezone-olson) packages to add awareness of `tz database` information.
@@ -23,12 +32,13 @@ With that, you can look up the UTC time at a point in time and space:
 
 ```haskell
 >>> import Data.Time
+>> db <- openTimeZoneDatabase "./test/tz_db/timezone21.bin"
 >>> localWinter <- parseTimeM True defaultTimeLocale "%Y-%-m-%-d %T" "2019-12-25 00:30:00"
->>> utcTime <- timeAtPointToUTC "./test/tz_db/timezone21.bin" 40.7831 (-73.9712) localWinter
+>>> utcTime <- timeAtPointToUTC db 40.7831 (-73.9712) localWinter
 2019-12-25 05:30:00 UTC
 
 >>> localSummer <- parseTimeM True defaultTimeLocale "%Y-%-m-%-d %T" "2019-07-25 00:30:00"
->>> utcTime <- timeAtPointToUTC "./test/tz_db/timezone21.bin" 40.7831 (-73.9712) localWinter
+>>> utcTime <- timeAtPointToUTC db 40.7831 (-73.9712) localWinter
 2019-07-25 04:30:00 UTC
 ```
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                timezone-detect 
-version:             0.2.2.0
+version:             0.3.0.0
 github:              "lfborjas/timezone-detect"
 license:             GPL-2
 author:              "Luis Borjas Reyes"

--- a/src/Data/Time/LocalTime/TimeZone/Detect.hs
+++ b/src/Data/Time/LocalTime/TimeZone/Detect.hs
@@ -61,7 +61,7 @@ type TimeZoneDatabase = Ptr ZoneDetectInfo
 -- Once in possesion of said files, the lookup looks as follows:
 -- 
 -- >>> db <- openTimeZoneDatabase "./test/tz_db/timezone21.bin" 
--- >>> tz <- lookupTimeZoneName db 40.7831 (-73.9712) :: Maybe TimeZoneName
+-- >>> let tz = lookupTimeZoneName db 40.7831 (-73.9712) :: Maybe TimeZoneName
 -- Just "America/New_York"
 -- >>> closeTimeZoneDatabase db
 -- 
@@ -132,6 +132,8 @@ openTimeZoneDatabase databaseLocation =
 closeTimeZoneDatabase :: TimeZoneDatabase -> IO ()
 closeTimeZoneDatabase = c_ZDCloseDatabase
 
+-- | Given a path to a timezone database file, and a computation to run with it,
+-- takes care of opening the file, running the computation and then closing it.
 withTimeZoneDatabase :: FilePath -> (TimeZoneDatabase -> IO a) -> IO a
 withTimeZoneDatabase databaseLocation = 
     bracket (openTimeZoneDatabase databaseLocation)

--- a/src/Foreign/ZoneDetect.hsc
+++ b/src/Foreign/ZoneDetect.hsc
@@ -8,24 +8,10 @@ import Foreign.C.String
 
 #include <zonedetect.h>
 
--- https://github.com/BertoldVdb/ZoneDetect/blob/05567e367576d7f3efa00083b7661a01e43dc8ca/library/zonedetect.c#L61
--- note that we define the non-Windows version. This library will not compile in Windows systems! (sorry, I just
--- don't know enough Haskell CPP directive-fu yet!)
+-- | Opaque pointer to the underlying C struct:
+-- https://wiki.haskell.org/FFI_cook_book#Passing_opaque_structures.2Ftypes
+-- https://github.com/BertoldVdb/ZoneDetect/blob/05567e367576d7f3efa00083b7661a01e43dc8ca/library/zonedetect.h
 data ZoneDetectInfo = ZoneDetectInfo
-    { fd :: Int
-    , length :: CInt -- as per: https://hackage.haskell.org/package/bindings-posix-1.2.4/docs/Bindings-Posix-Sys-Types.html
-    , closeType :: Word8
-    , mapping :: Ptr Word8
-    , tableType :: Word8
-    , version :: Word8
-    , precision :: Word8
-    , numFields :: Word8
-    , notice :: CString
-    , fieldNames :: Ptr CString
-    , bboxOffset :: Word32
-    , metadataOffset :: Word32
-    , dataOffset :: Word32
-    }
 
 foreign import ccall unsafe "zonedetect.h ZDOpenDatabase"
     c_ZDOpenDatabase :: CString -> IO (Ptr ZoneDetectInfo)

--- a/src/Foreign/ZoneDetect.hsc
+++ b/src/Foreign/ZoneDetect.hsc
@@ -30,5 +30,8 @@ data ZoneDetectInfo = ZoneDetectInfo
 foreign import ccall unsafe "zonedetect.h ZDOpenDatabase"
     c_ZDOpenDatabase :: CString -> IO (Ptr ZoneDetectInfo)
 
+foreign import ccall unsafe "zonedetect.hs ZDCloseDatabase"
+    c_ZDCloseDatabase :: Ptr ZoneDetectInfo -> IO ()
+
 foreign import ccall unsafe "zonedetect.h ZDHelperSimpleLookupString"
     c_ZDHelperSimpleLookupString :: Ptr ZoneDetectInfo -> CFloat -> CFloat -> IO CString

--- a/timezone-detect.cabal
+++ b/timezone-detect.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 03ea7e2e9760969e8b6c4e2a5f8cb5a17b448db1b6b3d5749e18cf3f7336553a
+-- hash: cada8fe310ed1ed1c85911dc9e3b40c06e5e111b2984429f42aa5a762a956c9a
 
 name:           timezone-detect
-version:        0.2.2.0
+version:        0.3.0.0
 synopsis:       Haskell bindings for the zone-detect C library; plus tz-aware utils.
 description:    Please see the README on GitHub at <https://github.com/lfborjas/timezone-detect#readme>
 category:       Data, Foreign, Time


### PR DESCRIPTION
Breaking change: looking at the original lib more closely, it was
definitely a mistake to not be able to close the database file; split
that into a convenience fn that opens/closes using a `bracket`,
and focus the original focus function into taking said database.

Closes #3